### PR TITLE
Change Mac build target to arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ifeq (${THIS_OS},windows)
 	msbuild.exe ./projects/${PROJECT_NAME}.sln -p:Platform="windows";Configuration=Release -target:${PROJECT_NAME}
 endif
 ifeq (${THIS_OS},darwin)
-	xcodebuild -configuration "Release" ARCHS="x86_64" -destination 'platform=macOS' -project "projects/${PROJECT_NAME}.xcodeproj" -target ${PROJECT_NAME}
+	xcodebuild -configuration "Release" ARCHS="arm64" -destination 'platform=macOS' -project "projects/${PROJECT_NAME}.xcodeproj" -target ${PROJECT_NAME}
 endif
 ifeq (${THIS_OS},linux)
 	make -C projects ${PROJECT_NAME} config=release_linux64
@@ -111,7 +111,7 @@ ifeq (${THIS_OS},windows)
 	msbuild.exe ./projects/${PROJECT_NAME}.sln -p:Platform="windows";Configuration=Debug -target:test
 endif
 ifeq (${THIS_OS},darwin)
-	xcodebuild -configuration "Debug" ARCHS="x86_64" -destination 'platform=macOS' -project "projects/test.xcodeproj" -target test
+	xcodebuild -configuration "Debug" ARCHS="arm64" -destination 'platform=macOS' -project "projects/test.xcodeproj" -target test
 endif
 ifeq (${THIS_OS},linux)
 	make -C projects test config=debug_linux64

--- a/premake5.lua
+++ b/premake5.lua
@@ -25,8 +25,8 @@ filter "configurations:Release"
   optimize "On"
   defines { "NDEBUG" }
 
--- Architecture is x86_64 by default
-architecture "x86_64"
+-- Architecture is ARM64 by default
+architecture "ARM64"
 
 filter "system:windows"
   defines {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -54,16 +54,20 @@ details:
 
 
 build-version: details
-	@echo 
+	@echo
 	@echo Building version - version header generation tool
 ifeq (${THIS_OS},windows)
-	env GOOS=windows go build -o ${TOOL_PATH}/version.exe src/version/main.go 
+	env GOOS=windows go build -o ${TOOL_PATH}/version.exe src/version/main.go
 endif
 ifeq (${THIS_OS},darwin)
-	GOOS=darwin go build -o ${TOOL_PATH}/version src/version/main.go 
+	ifeq (${THIS_ARCH},arm64)
+		GOOS=darwin GOARCH=arm64 go build -o ${TOOL_PATH}/version src/version/main.go
+	else
+		GOOS=darwin GOARCH=amd64 go build -o ${TOOL_PATH}/version src/version/main.go
+	endif
 endif
 ifeq (${THIS_OS},linux)
-	GOOS=linux go build -o ${TOOL_PATH}/version src/version/main.go 
+	GOOS=linux go build -o ${TOOL_PATH}/version src/version/main.go
 endif
 
 build-version-all: details

--- a/wasm_verify/Makefile
+++ b/wasm_verify/Makefile
@@ -23,8 +23,12 @@ else ifeq ($(UNAME_S),Darwin)
     LIB_EXT = dylib
     LIB_FLAGS = -dynamiclib
     PLATFORM = darwin
-    # Force x86_64 to match the C build (premake5.lua defaults to x86_64)
-    GOARCH = amd64
+    # Match the architecture from the main build
+    ifeq ($(UNAME_M),arm64)
+        GOARCH = arm64
+    else
+        GOARCH = amd64
+    endif
 else ifneq (,$(findstring MINGW,$(UNAME_S)))
     LIB_EXT = dll
     LIB_FLAGS = -shared


### PR DESCRIPTION
- Update xcodebuild commands in Makefile to use ARCHS="arm64" for both Release and Debug builds
- Change default architecture in premake5.lua from x86_64 to ARM64
- This makes arm64 (Apple Silicon) the default Mac build target instead of x86_64 (Intel)