### PR TITLE
Fix code quality issues in linker and tests

### DIFF
--- a/src/native/section_layout.c
+++ b/src/native/section_layout.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /*
  * Section Layout & Address Assignment Implementation
@@ -541,8 +542,8 @@ void section_layout_print(section_layout_t* layout) {
     }
 
     printf("Section Layout:\n");
-    printf("  Base address: 0x%016llx\n", layout->base_address);
-    printf("  Total size: %llu bytes (0x%llx)\n", layout->total_size, layout->total_size);
+    printf("  Base address: 0x%016" PRIx64 "\n", layout->base_address);
+    printf("  Total size: %" PRIu64 " bytes (0x%" PRIx64 ")\n", layout->total_size, layout->total_size);
     printf("  Page size: %zu bytes\n", layout->page_size);
     printf("  Platform: %s\n", platform_format_name(layout->target_format));
     printf("\n");
@@ -552,7 +553,7 @@ void section_layout_print(section_layout_t* layout) {
         merged_section_t* section = &layout->sections[i];
         printf("  [%d] %s (%s)\n", i, section->name,
                section_type_name(section->type));
-        printf("      Virtual address: 0x%016llx\n", section->vaddr);
+        printf("      Virtual address: 0x%016" PRIx64 "\n", section->vaddr);
         printf("      Size: %zu bytes (0x%zx)\n", section->size, section->size);
         printf("      Alignment: %zu bytes\n", section->alignment);
         printf("      Flags: 0x%08x\n", section->flags);

--- a/src/native/symbol_resolver.c
+++ b/src/native/symbol_resolver.c
@@ -637,7 +637,7 @@ bool symbol_resolver_compute_addresses(symbol_resolver_t* resolver,
                  * The section_index references the merged section in the layout.
                  */
                 if (sym->section_index >= layout->section_count) {
-                    fprintf(stderr, "Symbol resolver error: Symbol '%s' references "
+                    fprintf(stderr, "Internal error: Symbol resolver: Symbol '%s' references "
                             "invalid section %d (max %d)\n",
                             sym->name, sym->section_index, layout->section_count - 1);
                     return false;

--- a/src/test/relocation_processor_test.c
+++ b/src/test/relocation_processor_test.c
@@ -582,7 +582,7 @@ static MunitTest relocation_processor_tests[] = {
 };
 
 static const MunitSuite relocation_processor_suite = {
-    "sox//linker/relocation_processor",
+    "sox/linker/relocation_processor",
     relocation_processor_tests,
     NULL,
     1,

--- a/src/test/section_layout_test.c
+++ b/src/test/section_layout_test.c
@@ -14,6 +14,7 @@
 #include "../../ext/munit/munit.h"
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /* Test: Create and destroy section layout */
 static MunitResult test_section_layout_lifecycle(const MunitParameter params[], void* data) {

--- a/src/test/symbol_resolver_test.c
+++ b/src/test/symbol_resolver_test.c
@@ -425,6 +425,7 @@ static MunitResult test_hash_table_resize(const MunitParameter params[], void* d
     linker_object_t* obj = linker_object_new("test.o", PLATFORM_FORMAT_ELF);
 
     /* Add enough symbols to exceed load factor */
+    /* Explicitly truncate to int (intentional floor operation for test capacity) */
     int num_symbols = (int)(initial_size * 0.8);  /* 80% of initial capacity */
     for (int i = 0; i < num_symbols; i++) {
         linker_symbol_t* sym = linker_object_add_symbol(obj);


### PR DESCRIPTION
Addresses multiple code quality and portability concerns:

1. symbol_resolver_test.c:428 - Add explicit comment about intentional
   truncation in double-to-int cast for test capacity calculation

2. section_layout_test.c - Add <inttypes.h> header for portable
   uint64_t formatting (PRIx64/PRIu64 macros)

3. relocation_processor_test.c:585 - Fix double slash in test suite
   name ("sox//linker" -> "sox/linker")

4. symbol_resolver.c:640-643 - Add "Internal error:" prefix to error
   message to distinguish from user-facing errors, clarifying this is
   a critical internal validation failure

5. section_layout.c - Replace non-portable %llx/%llu format specifiers
   with PRIx64/PRIu64 from <inttypes.h> for proper uint64_t formatting
   across all platforms