### PR TITLE
Add --custom-linker flag for native code generation

### DIFF
--- a/src/lib/arg_parser.c
+++ b/src/lib/arg_parser.c
@@ -27,12 +27,13 @@ void print_help(const char* program_name) {
     struct arg_lit* native_obj = arg_lit0(NULL, "native-obj", "Emit object file (skip linking)");
     struct arg_lit* native_debug = arg_lit0(NULL, "native-debug", "Enable debug output during native code generation");
     struct arg_int* native_opt = arg_int0(NULL, "native-opt", "LEVEL", "Optimization level 0-3 (default: 0)");
+    struct arg_lit* custom_linker = arg_lit0(NULL, "custom-linker", "Use Sox custom linker instead of system linker (experimental)");
 
     struct arg_end* end = arg_end(20);
 
     void* argtable[] = { help, version, input, serialise, suppress, wasm, wat,
                          native, native_out, native_arch, native_os, native_obj,
-                         native_debug, native_opt, end };
+                         native_debug, native_opt, custom_linker, end };
 
     printf("Sox %s\n", VERSION);
     printf("A bytecode-based virtual machine interpreter for a toy programming language\n");
@@ -54,6 +55,8 @@ void print_help(const char* program_name) {
     printf("                                  Generate object file instead of executable\n");
     printf("  %s script.sox --native --native-arch arm64 --native-os macos\n", program_name);
     printf("                                  Cross-compile to ARM64 macOS\n");
+    printf("  %s script.sox --native --custom-linker\n", program_name);
+    printf("                                  Use custom Sox linker (experimental)\n");
     printf("  %s script.sox --serialise       Cache compiled bytecode\n", program_name);
     printf("\nFor more information, visit: https://github.com/freneticmonkey/sox\n");
 
@@ -99,12 +102,13 @@ bool parse_arguments(int argc, const char* argv[], sox_args_t* args) {
     struct arg_lit* native_obj = arg_lit0(NULL, "native-obj", "Emit object file");
     struct arg_lit* native_debug = arg_lit0(NULL, "native-debug", "Debug output");
     struct arg_int* native_opt = arg_int0(NULL, "native-opt", "LEVEL", "Optimization level 0-3");
+    struct arg_lit* custom_linker = arg_lit0(NULL, "custom-linker", "Use custom linker");
 
     struct arg_end* end = arg_end(20);
 
     void* argtable[] = { help, version, input, serialise, suppress, wasm, wat,
                          native, native_out, native_arch, native_os, native_obj,
-                         native_debug, native_opt, end };
+                         native_debug, native_opt, custom_linker, end };
 
     // Parse arguments
     int nerrors = arg_parse(argc, (char**)argv, argtable);
@@ -211,6 +215,7 @@ bool parse_arguments(int argc, const char* argv[], sox_args_t* args) {
         // Default to executable (emit_object = false) unless --native-obj is specified
         args->native_emit_object = (native_obj->count > 0);
         args->native_debug_output = (native_debug->count > 0);
+        args->use_custom_linker = (custom_linker->count > 0);
 
         if (native_opt->count > 0) {
             int opt_level = native_opt->ival[0];

--- a/src/lib/arg_parser.h
+++ b/src/lib/arg_parser.h
@@ -28,6 +28,7 @@ typedef struct {
     bool native_emit_object;
     bool native_debug_output;
     int native_optimization_level;  // 0-3
+    bool use_custom_linker;    // Use custom linker instead of system linker
 
     // Internal
     int argc;

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,7 @@ int main(int argc, const char* argv[]) {
         config.native_emit_object = args.native_emit_object;
         config.native_debug_output = args.native_debug_output;
         config.native_optimization_level = args.native_optimization_level;
+        config.use_custom_linker = args.use_custom_linker;
 
         l_init_memory();
         l_init_vm(&config);
@@ -90,6 +91,7 @@ int main(int argc, const char* argv[]) {
         config.native_emit_object = args.native_emit_object;
         config.native_debug_output = args.native_debug_output;
         config.native_optimization_level = args.native_optimization_level;
+        config.use_custom_linker = args.use_custom_linker;
 
         int status = l_run_file(&config);
 

--- a/src/vm_config.h
+++ b/src/vm_config.h
@@ -30,6 +30,7 @@ typedef struct {
     bool native_emit_object;
     bool native_debug_output;
     int native_optimization_level;
+    bool use_custom_linker;        // Use custom linker instead of system linker
 
     vm_args_t args;
 } vm_config_t;


### PR DESCRIPTION
## Summary

This PR adds the `--custom-linker` CLI flag to enable the custom linker for native code generation. The system linker remains the default for stability.

## Changes

### CLI Flag Infrastructure
- Added `use_custom_linker` field to `sox_args_t` and `vm_config_t`
- Implemented `--custom-linker` flag parsing with help text and examples
- Flag is threaded through both REPL and file execution modes

### Linker Integration
- Updated `_generate_native()` to use unified `linker_link()` API
- Set linker mode based on `use_custom_linker` flag (CUSTOM vs SYSTEM)
- Updated `linker_is_simple_link_job()` heuristic for platform support detection
- Removed redundant linker detection code

### Current Behavior
- **Default** (no flag): Uses system linker (gcc/clang/ld) - **no regression**
- **With `--custom-linker`**: Shows warning and falls back to system linker

```bash
Warning: Custom linker integration not yet complete
Falling back to system linker...
```

## Why Fallback?

The custom linker phases (1-5) are implemented but use specialized types (`symbol_resolver_t`, `section_layout_t`, `relocation_processor_t`) that need proper orchestration with `linker_context_t`. This integration layer requires additional work.

The current approach:
- ✅ Adds flag infrastructure (future-proof)
- ✅ Maintains system linker as default (stable)
- ✅ No breaking changes (backward compatible)
- ⏳ Defers custom linker execution (until integration complete)

## Files Modified
- `src/lib/arg_parser.h` - Added `use_custom_linker` field
- `src/lib/arg_parser.c` - Added CLI flag parsing and help text
- `src/vm_config.h` - Added `use_custom_linker` config field
- `src/main.c` - Copy flag from args to config (REPL & file modes)
- `src/lib/file.c` - Use `linker_link()` API with mode selection
- `src/lib/linker.c` - Updated link job heuristic, added fallback

## Testing

```bash
# Help shows the flag
./build/sox --help | grep custom-linker

# Flag is recognized
./build/sox script.sox --native --custom-linker
# Shows: Warning: Custom linker integration not yet complete

# System linker still works (no regression)
./build/sox script.sox --native
```

## Next Steps

To complete custom linker integration:
1. Create proper initialization of `symbol_resolver_t`, `section_layout_t`, etc. from `linker_context_t`
2. Uncomment and fix the Phase 1-5 orchestration code in `linker_link_custom()`
3. Add the custom linker headers back
4. Test end-to-end with real object files

The flag infrastructure is ready - just the orchestration layer needs completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)