### PR TITLE
Claude/fix elf warnings

### DIFF
--- a/src/native/elf_reader.c
+++ b/src/native/elf_reader.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 /*
  * ELF Object File Reader Implementation
@@ -26,7 +27,7 @@
 #define CHECK_OFFSET_SIZE(offset, size, limit, msg) \
     do { \
         if ((size) > 0 && (offset) > (limit) - (size)) { \
-            fprintf(stderr, "ELF reader error: %s (offset=%llu, size=%llu, limit=%zu)\n", \
+            fprintf(stderr, "ELF reader error: %s (offset=%" PRIu64 ", size=%" PRIu64 ", limit=%zu)\n", \
                     (msg), (uint64_t)(offset), (uint64_t)(size), (size_t)(limit)); \
             return false; \
         } \
@@ -326,7 +327,7 @@ static bool elf_parse_symbols(linker_object_t* obj, elf_parse_context_t* ctx) {
          * ensure the string is properly null-terminated.
          */
         if (elf_sym->st_name >= strtab_shdr->sh_size) {
-            fprintf(stderr, "ELF reader error: Symbol %d name index %u out of bounds (strtab size: %llu)\n",
+            fprintf(stderr, "ELF reader error: Symbol %d name index %u out of bounds (strtab size: %" PRIu64 ")\n",
                     i, elf_sym->st_name, (uint64_t)strtab_shdr->sh_size);
             return false;
         }


### PR DESCRIPTION
Fix format specifier warnings in ELF reader
Resolves compilation warnings on Linux x86_64 by using portable PRIu64
format macro instead of %llu for uint64_t values.

1. Fix format specifier warnings in ELF reader (src/native/elf_reader.c)
  - Added #include <inttypes.h>
  - Used portable PRIu64 macro instead of %llu for uint64_t values
  - Ensures correct formatting across all platforms

  2. Fix buffer truncation warning with bounds checking (src/lib/file.c)
  - Increased temp_object buffer from 256 to 512 bytes
  - Added explicit length validation before snprintf
  - Returns error with clear message if path exceeds buffer capacity
  - Prevents overflow even with very long paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>